### PR TITLE
Improve recipe execution logging

### DIFF
--- a/mcp-servers/recipe-tool/recipe_tool_mcp_server/cli.py
+++ b/mcp-servers/recipe-tool/recipe_tool_mcp_server/cli.py
@@ -2,11 +2,11 @@
 MCP server wrapping the recipe-tool CLI.
 Provides two tools: execute_recipe and create_recipe.
 """
+
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 # Import the CLI functions
-import recipe_tool
 from recipe_tool import execute_recipe as cli_execute, create_recipe as cli_create
 
 # Load environment variables from .env if present
@@ -15,12 +15,9 @@ load_dotenv()
 # Initialize the MCP server
 mcp = FastMCP("Recipe Tool Server")
 
+
 @mcp.tool()
-async def execute_recipe(
-    recipe_path: str,
-    context: dict[str, str] | None = None,
-    log_dir: str = "logs"
-) -> str:
+async def execute_recipe(recipe_path: str, context: dict[str, str] | None = None, log_dir: str = "logs") -> str:
     """
     Execute a recipe JSON file.
     """
@@ -30,12 +27,9 @@ async def execute_recipe(
     await cli_execute(recipe_path, context_list, log_dir)
     return f"Recipe executed successfully (logs in {log_dir})"
 
+
 @mcp.tool()
-async def create_recipe(
-    idea_path: str,
-    context: dict[str, str] | None = None,
-    log_dir: str = "logs"
-) -> str:
+async def create_recipe(idea_path: str, context: dict[str, str] | None = None, log_dir: str = "logs") -> str:
     """
     Create a recipe from an idea file.
     """
@@ -43,11 +37,13 @@ async def create_recipe(
     await cli_create(idea_path, context_list, log_dir)
     return f"Recipe created successfully (logs in {log_dir})"
 
+
 def main() -> None:
     """
     Entry point for the MCP server.
     """
     mcp.run()
+
 
 if __name__ == "__main__":
     main()

--- a/recipe_executor/executor.py
+++ b/recipe_executor/executor.py
@@ -79,16 +79,16 @@ class Executor(ExecutorProtocol):
             summary = recipe_model.model_dump()
         except Exception:
             summary = {}
-        step_count = len(getattr(recipe_model, 'steps', []))
+        step_count = len(getattr(recipe_model, "steps", []))
         self.logger.debug(f"Recipe loaded: {summary}. Steps count: {step_count}")
 
         # Execute each step sequentially
         for idx, step in enumerate(recipe_model.steps):  # type: ignore
             step_type = step.type
             config = step.config or {}
-            self.logger.debug(
-                f"Executing step {idx} of type '{step_type}' with config: {config}"
-            )
+            # Surface high level progress at INFO and detailed config at DEBUG
+            self.logger.info(f"Starting step {idx}: {step_type}")
+            self.logger.debug(f"Executing step {idx} of type '{step_type}' with config: {config}")
 
             if step_type not in STEP_REGISTRY:
                 raise ValueError(f"Unknown step type '{step_type}' at index {idx}")
@@ -104,6 +104,7 @@ class Executor(ExecutorProtocol):
                 msg = f"Error executing step {idx} ('{step_type}'): {e}"
                 raise ValueError(msg) from e
 
+            self.logger.info(f"Completed step {idx}: {step_type}")
             self.logger.debug(f"Step {idx} ('{step_type}') completed successfully.")
 
-        self.logger.debug("All recipe steps completed successfully.")
+        self.logger.info("All recipe steps completed successfully.")

--- a/recipes/document_generator/README.md
+++ b/recipes/document_generator/README.md
@@ -6,6 +6,9 @@
 # From the repo root, run the document generator recipe to create a readme for the codebase.
 recipe-tool --execute recipes/document_generator/document-generator-recipe.json \
    outline_file=recipes/document_generator/examples/readme.json \
-   output_root=output/docs \
-   model=openai/o4-mini
+  output_root=output/docs \
+  model=openai/o4-mini
 ```
+
+While the recipe runs, progress information is printed to the console so you can
+see each step being executed.


### PR DESCRIPTION
## Summary
- show progress info during recipe execution by logging step start and completion
- document that progress logs are printed while running document generator
- remove unused import from MCP server CLI

## Testing
- `ruff format mcp-servers/recipe-tool/recipe_tool_mcp_server/cli.py recipe_executor/executor.py`
- `ruff check mcp-servers/recipe-tool/recipe_tool_mcp_server/cli.py recipe_executor/executor.py`
- `pytest`